### PR TITLE
INP-53- Running flights for familiar routes

### DIFF
--- a/scripts/conf/f15c/f15c_beta_flight_mumbai_to_delhi.properties
+++ b/scripts/conf/f15c/f15c_beta_flight_mumbai_to_delhi.properties
@@ -1,0 +1,55 @@
+#config directives for f15c beta in flight operation
+#ensure these hosts/ports match the shell script launching fgfs
+#reserve ports 5220-5239
+
+#################
+# aircraft name
+aircraftName=F15C_Beta
+
+#################
+# simulator telemetry socket
+telemetryHost=localhost
+telemetryPort=5220
+
+#################
+# simulator telnet server
+telnetHost=localhost
+telnetPort=5221
+
+#################
+# simulator httpd server with camera view
+cameraViewHost=localhost
+cameraViewPort=5222
+
+#################
+# control inputs
+controlInputHost=localhost
+
+consumeablesInputPort=5223
+controlsInputPort=5224
+enginesInputPort=5225
+fdmInputPort=5226
+orientationInputPort=5227
+positionInputPort=5228
+simInputPort=5229
+simFreezeInputPort=5230
+simModelInputPort=5231
+simSpeedupInputPort=5232
+simTimeInputPort=5233
+systemsInputPort=5234
+velocitiesInputPort=5235
+
+#################
+# sshd server
+sshUser=edge
+sshPass=twxedge
+sshdPort=5239
+sshdHomeDir=/tmp/f15c_beta
+
+#################
+# mjpeg streaming of camera view
+cameraStreamHost=localhost
+cameraStreamPort=5238
+
+#################
+flightPlanName=Delhi Tour

--- a/scripts/conf/f15c/f15c_beta_flight_ngp_to_pune.properties
+++ b/scripts/conf/f15c/f15c_beta_flight_ngp_to_pune.properties
@@ -1,0 +1,55 @@
+#config directives for f15c beta in flight operation
+#ensure these hosts/ports match the shell script launching fgfs
+#reserve ports 5220-5239
+
+#################
+# aircraft name
+aircraftName=F15C_Beta
+
+#################
+# simulator telemetry socket
+telemetryHost=localhost
+telemetryPort=5220
+
+#################
+# simulator telnet server
+telnetHost=localhost
+telnetPort=5221
+
+#################
+# simulator httpd server with camera view
+cameraViewHost=localhost
+cameraViewPort=5222
+
+#################
+# control inputs
+controlInputHost=localhost
+
+consumeablesInputPort=5223
+controlsInputPort=5224
+enginesInputPort=5225
+fdmInputPort=5226
+orientationInputPort=5227
+positionInputPort=5228
+simInputPort=5229
+simFreezeInputPort=5230
+simModelInputPort=5231
+simSpeedupInputPort=5232
+simTimeInputPort=5233
+systemsInputPort=5234
+velocitiesInputPort=5235
+
+#################
+# sshd server
+sshUser=edge
+sshPass=twxedge
+sshdPort=5239
+sshdHomeDir=/tmp/f15c_beta
+
+#################
+# mjpeg streaming of camera view
+cameraStreamHost=localhost
+cameraStreamPort=5238
+
+#################
+flightPlanName=Pune Tour

--- a/scripts/f15c_flight.sh
+++ b/scripts/f15c_flight.sh
@@ -8,7 +8,7 @@ FG_AIRCRAFT=org.flightgear.fgaddon.stable_2020.f15c
 #find the AppImage on the path
 #keep consistent with fg_launcher.sh
 
-APPIMAGE_FILE=FlightGear-2020.3.18-x86_64.AppImage
+APPIMAGE_FILE=FlightGear-2020.3.17-x86_64.AppImage
 
 FG_BIN_PATH=`whereis -b $APPIMAGE_FILE | awk '{print $2}'`
 

--- a/scripts/f15c_flight.sh
+++ b/scripts/f15c_flight.sh
@@ -105,8 +105,8 @@ ALT=9000
 
 ########
 #start position, default to yvr 49.19524, -123.18084
-START_LAT=${3:-21.09016}
-START_LON=${4:-79.05223}
+START_LAT=${3:-49.19524}
+START_LON=${4:--123.18084}
 
 ########
 #name of this aircraft

--- a/scripts/f15c_flight.sh
+++ b/scripts/f15c_flight.sh
@@ -8,7 +8,7 @@ FG_AIRCRAFT=org.flightgear.fgaddon.stable_2020.f15c
 #find the AppImage on the path
 #keep consistent with fg_launcher.sh
 
-APPIMAGE_FILE=FlightGear-2020.3.17-x86_64.AppImage
+APPIMAGE_FILE=FlightGear-2020.3.18-x86_64.AppImage
 
 FG_BIN_PATH=`whereis -b $APPIMAGE_FILE | awk '{print $2}'`
 
@@ -105,8 +105,8 @@ ALT=9000
 
 ########
 #start position, default to yvr 49.19524, -123.18084
-START_LAT=${3:-49.19524}
-START_LON=${4:--123.18084}
+START_LAT=${3:-21.09016}
+START_LON=${4:-79.05223}
 
 ########
 #name of this aircraft

--- a/src/main/java/org/jason/fgcontrol/flight/position/KnownPositions.java
+++ b/src/main/java/org/jason/fgcontrol/flight/position/KnownPositions.java
@@ -94,4 +94,17 @@ public abstract class KnownPositions {
     public final static WaypointPosition SANDIEGO_PTC_OFFICE = new WaypointPosition(32.93657, -117.23303, "San Diego PTC Office");
     public final static WaypointPosition BOSTON_PTC_OFFICE = new WaypointPosition(42.35120, -71.04463, "Boston Seaport PTC Office");
     public final static WaypointPosition PORTLAND_PTC_OFFICE = new WaypointPosition(43.65848, -70.25726, "Portland PTC Office");
+    
+    // Familiar Routes
+    //public final static WaypointPosition NAGPUR_AIRPORT = new WaypointPosition(21.09016, 79.05223, "Nagpur International Airport");
+    public final static WaypointPosition AMRAVATI_CITY = new WaypointPosition(20.90422, 77.67934, "Amravati City");
+    public final static WaypointPosition BHUSAVAL_CITY = new WaypointPosition(21.03964, 75.76847, "Bhusaval City");
+    public final static WaypointPosition AHMEDNAGAR_CITY = new WaypointPosition(19.11046, 74.66027, "Ahmednagar City");
+    public final static WaypointPosition DAUND_CITY = new WaypointPosition(18.45720, 74.56167, "Daund City");
+    public final static WaypointPosition PUNE_AIRPORT = new WaypointPosition(18.57934, 73.90634, "Pune International Airport");
+
+//     public final static WaypointPosition PCCOE_COLLEGE = new WaypointPosition(18.65215, -73.76161, "PCCOE College");
+//     public final static WaypointPosition BOMBAY_SAPPERS = new WaypointPosition(18.56080, -73.92120, "Bombay Sappers");
+//     public final static WaypointPosition PUNE_AIRPORT = new WaypointPosition(18.57934, -73.90617, "Pune International Airport");
+//     public final static WaypointPosition NAGPUR_AIRPORT = new WaypointPosition(21.09016, 79.05223, "Nagpur International Airport");
 }

--- a/src/main/java/org/jason/fgcontrol/flight/position/KnownPositions.java
+++ b/src/main/java/org/jason/fgcontrol/flight/position/KnownPositions.java
@@ -95,7 +95,7 @@ public abstract class KnownPositions {
     public final static WaypointPosition BOSTON_PTC_OFFICE = new WaypointPosition(42.35120, -71.04463, "Boston Seaport PTC Office");
     public final static WaypointPosition PORTLAND_PTC_OFFICE = new WaypointPosition(43.65848, -70.25726, "Portland PTC Office");
     
-    // Familiar Routes in India
+    // Familiar Places in India
     public final static WaypointPosition AMRAVATI_CITY = new WaypointPosition(20.90422, 77.67934, "Amravati City");
     public final static WaypointPosition BHUSAVAL_CITY = new WaypointPosition(21.03964, 75.76847, "Bhusaval City");
     public final static WaypointPosition AHMEDNAGAR_CITY = new WaypointPosition(19.11046, 74.66027, "Ahmednagar City");

--- a/src/main/java/org/jason/fgcontrol/flight/position/KnownPositions.java
+++ b/src/main/java/org/jason/fgcontrol/flight/position/KnownPositions.java
@@ -101,7 +101,6 @@ public abstract class KnownPositions {
     public final static WaypointPosition AHMEDNAGAR_CITY = new WaypointPosition(19.11046, 74.66027, "Ahmednagar City");
     public final static WaypointPosition DAUND_CITY = new WaypointPosition(18.45720, 74.56167, "Daund City");
     public final static WaypointPosition PUNE_AIRPORT = new WaypointPosition(18.57934, 73.90634, "Pune International Airport");
-
     public final static WaypointPosition SURAT_CITY = new WaypointPosition(21.15934, 72.73989, "Surat City");
     public final static WaypointPosition VADODARA_CITY = new WaypointPosition(22.32224, 73.09068, "Vadodara City");
     public final static WaypointPosition RATLAM_CITY = new WaypointPosition(23.33676, 75.00124, "Ratlam City");

--- a/src/main/java/org/jason/fgcontrol/flight/position/KnownPositions.java
+++ b/src/main/java/org/jason/fgcontrol/flight/position/KnownPositions.java
@@ -95,16 +95,16 @@ public abstract class KnownPositions {
     public final static WaypointPosition BOSTON_PTC_OFFICE = new WaypointPosition(42.35120, -71.04463, "Boston Seaport PTC Office");
     public final static WaypointPosition PORTLAND_PTC_OFFICE = new WaypointPosition(43.65848, -70.25726, "Portland PTC Office");
     
-    // Familiar Routes
-    //public final static WaypointPosition NAGPUR_AIRPORT = new WaypointPosition(21.09016, 79.05223, "Nagpur International Airport");
+    // Familiar Routes in India
     public final static WaypointPosition AMRAVATI_CITY = new WaypointPosition(20.90422, 77.67934, "Amravati City");
     public final static WaypointPosition BHUSAVAL_CITY = new WaypointPosition(21.03964, 75.76847, "Bhusaval City");
     public final static WaypointPosition AHMEDNAGAR_CITY = new WaypointPosition(19.11046, 74.66027, "Ahmednagar City");
     public final static WaypointPosition DAUND_CITY = new WaypointPosition(18.45720, 74.56167, "Daund City");
     public final static WaypointPosition PUNE_AIRPORT = new WaypointPosition(18.57934, 73.90634, "Pune International Airport");
 
-//     public final static WaypointPosition PCCOE_COLLEGE = new WaypointPosition(18.65215, -73.76161, "PCCOE College");
-//     public final static WaypointPosition BOMBAY_SAPPERS = new WaypointPosition(18.56080, -73.92120, "Bombay Sappers");
-//     public final static WaypointPosition PUNE_AIRPORT = new WaypointPosition(18.57934, -73.90617, "Pune International Airport");
-//     public final static WaypointPosition NAGPUR_AIRPORT = new WaypointPosition(21.09016, 79.05223, "Nagpur International Airport");
+    public final static WaypointPosition SURAT_CITY = new WaypointPosition(21.15934, 72.73989, "Surat City");
+    public final static WaypointPosition VADODARA_CITY = new WaypointPosition(22.32224, 73.09068, "Vadodara City");
+    public final static WaypointPosition RATLAM_CITY = new WaypointPosition(23.33676, 75.00124, "Ratlam City");
+    public final static WaypointPosition KOTA_CITY = new WaypointPosition(25.17353, 75.76456, "Kota City");
+    public final static WaypointPosition DELHI_CITY = new WaypointPosition(28.64428, 76.92842, "Delhi City");
 }

--- a/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
+++ b/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
@@ -24,7 +24,6 @@ public abstract class KnownRoutes {
             private static final long serialVersionUID = 3487720676170767955L;
 
             {
-               //add(KnownPositions.NAGPUR_AIRPORT)
                add(KnownPositions.AMRAVATI_CITY);
                add(KnownPositions.BHUSAVAL_CITY);
                add(KnownPositions.AHMEDNAGAR_CITY);
@@ -38,7 +37,6 @@ public abstract class KnownRoutes {
             private static final long serialVersionUID = 3487720676170767955L;
 
             {
-               //add(KnownPositions.NAGPUR_AIRPORT)
                add(KnownPositions.SURAT_CITY);
                add(KnownPositions.VADODARA_CITY);
                add(KnownPositions.RATLAM_CITY);
@@ -372,7 +370,7 @@ public abstract class KnownRoutes {
     	private static final long serialVersionUID = -8393587070456328149L;
 
 		{
-    		addAll(PUNE_TOUR);
+    		addAll(VANCOUVER_TOUR);
     	}
     };
 }

--- a/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
+++ b/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
@@ -19,30 +19,44 @@ public abstract class KnownRoutes {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(KnownRoutes.class);
 
-    public final static ArrayList<WaypointPosition> VANCOUVER_TOUR = new ArrayList<WaypointPosition>() {
+    public final static ArrayList<WaypointPosition> PUNE_TOUR = new ArrayList<WaypointPosition>() {
 
-        private static final long serialVersionUID = 3487720676170767955L;
-        
-        {
-            add( KnownPositions.UBC );
-            add( KnownPositions.STANLEY_PARK );
-            add( KnownPositions.LONSDALE_QUAY );
-            add( KnownPositions.MT_SEYMOUR );
-            add( KnownPositions.GROUSE_MOUNTAIN );
-            add( KnownPositions.WEST_LION );
-            add( KnownPositions.LANGDALE );
-            add( KnownPositions.BOWEN_BAY );
-            add( KnownPositions.HORSESHOE_BAY );
-            add( KnownPositions.MARPOLE_CC );
-            add( KnownPositions.BURNABY_8RINKS );
-            add( KnownPositions.PLANET_ICE_DELTA );
-            add( KnownPositions.VAN_INTER_AIRPORT_YVR );
-        }
-    };
-    
+            private static final long serialVersionUID = 3487720676170767955L;
+
+            {
+               //add(KnownPositions.NAGPUR_AIRPORT)
+               add(KnownPositions.AMRAVATI_CITY)
+               add(KnownPositions.BHUSAVAL_CITY)
+               add(KnownPositions.AHMEDNAGAR_CITY)
+               add(KnownPositions.DAUND_CITY)
+               add(KnownPositions.PUNE_AIRPORT)
+            }
+        };
+
+//     public final static ArrayList<WaypointPosition> VANCOUVER_TOUR = new ArrayList<WaypointPosition>() {
+//
+//         private static final long serialVersionUID = 3487720676170767955L;
+//
+//         {
+//             add( KnownPositions.UBC );
+//             add( KnownPositions.STANLEY_PARK );
+//             add( KnownPositions.LONSDALE_QUAY );
+//             add( KnownPositions.MT_SEYMOUR );
+//             add( KnownPositions.GROUSE_MOUNTAIN );
+//             add( KnownPositions.WEST_LION );
+//             add( KnownPositions.LANGDALE );
+//             add( KnownPositions.BOWEN_BAY );
+//             add( KnownPositions.HORSESHOE_BAY );
+//             add( KnownPositions.MARPOLE_CC );
+//             add( KnownPositions.BURNABY_8RINKS );
+//             add( KnownPositions.PLANET_ICE_DELTA );
+//             add( KnownPositions.VAN_INTER_AIRPORT_YVR );
+//         }
+//     };
+
     //flight plan with minimal course corrections starting from hs bay
     public final static ArrayList<WaypointPosition> VANCOUVER_NORTH_SHORE_DEMO = new ArrayList<WaypointPosition>() {
-    	
+
     	private static final long serialVersionUID = -1630760784238590060L;
 
 		{
@@ -51,7 +65,7 @@ public abstract class KnownRoutes {
     		add( KnownPositions.DEEP_COVE );
     	}
     };
-    
+
     public final static ArrayList<WaypointPosition> VANCOUVER_LOW_ALT_TOUR = new ArrayList<WaypointPosition>() {
 
         private static final long serialVersionUID = -1630760784238590060L;
@@ -69,7 +83,7 @@ public abstract class KnownRoutes {
             add( KnownPositions.VAN_INTER_AIRPORT_YVR );
         }
     };
-    
+
     public final static ArrayList<WaypointPosition> VANCOUVER_SHORT_TOUR = new ArrayList<WaypointPosition>() {
 
         private static final long serialVersionUID = -1630760784238590060L;
@@ -84,11 +98,11 @@ public abstract class KnownRoutes {
             add( KnownPositions.VAN_INTER_AIRPORT_YVR );
         }
     };
-    
+
     public final static ArrayList<WaypointPosition> BC_TOUR = new ArrayList<WaypointPosition>() {
 
         private static final long serialVersionUID = 762842417275059036L;
-        
+
         {
             {
                 add(KnownPositions.ABBOTSFORD);
@@ -118,7 +132,7 @@ public abstract class KnownRoutes {
             }
         }
     };
-    
+
     //flight plan with minimal course corrections starting from YVR
     public final static ArrayList<WaypointPosition> BC_SOUTH_DEMO = new ArrayList<WaypointPosition>() {
 
@@ -130,7 +144,7 @@ public abstract class KnownRoutes {
             }
         }
     };
-    
+
     public final static ArrayList<WaypointPosition> BC_SOUTH_TOUR = new ArrayList<WaypointPosition>() {
 
 		private static final long serialVersionUID = 9044191298704604870L;
@@ -151,7 +165,7 @@ public abstract class KnownRoutes {
             }
         }
     };
-    
+
     public final static ArrayList<WaypointPosition> VAN_ISLAND_TOUR = new ArrayList<WaypointPosition>() {
 
 		private static final long serialVersionUID = -6035401483530239855L;
@@ -164,7 +178,7 @@ public abstract class KnownRoutes {
             }
         }
     };
-    
+
     //initial heading yvr to chilliwack: 92
     public final static ArrayList<WaypointPosition> VAN_ISLAND_TOUR_SOUTH = new ArrayList<WaypointPosition>() {
 
@@ -179,7 +193,7 @@ public abstract class KnownRoutes {
             }
         }
     };
-    
+
     //initial heading yvr to tofino: 269
     public final static ArrayList<WaypointPosition> VAN_ISLAND_TOUR_SOUTH2 = new ArrayList<WaypointPosition>() {
 
@@ -193,10 +207,10 @@ public abstract class KnownRoutes {
             }
         }
     };
-    
+
     //initial heading yvr to powell river: 306
     public final static ArrayList<WaypointPosition> BC_WEST_COAST = new ArrayList<WaypointPosition>() {
-    	
+
     	private static final long serialVersionUID = 5196584768547503992L;
 
 		{
@@ -210,11 +224,11 @@ public abstract class KnownRoutes {
 			add(KnownPositions.VAN_INTER_AIRPORT_YVR);
     	}
     };
-    
+
     public final static ArrayList<WaypointPosition> PTC_NA_OFFICE_TOUR = new ArrayList<WaypointPosition>() {
 
         private static final long serialVersionUID = 8537287930892781019L;
-        
+
         {
             add(KnownPositions.SANDIEGO_PTC_OFFICE);
             add(KnownPositions.TUCSON_PTC_OFFICE);
@@ -227,22 +241,23 @@ public abstract class KnownRoutes {
             add(KnownPositions.TROIS_RIVIERES_PTC_OFFICE);
             add(KnownPositions.PORTLAND_PTC_OFFICE);
             add(KnownPositions.BOSTON_PTC_OFFICE);
-            
+
         }
     };
-    
+
     ///////////
-    
-    //KNOWN_ROUTES needs to execute its initializer after its prospective hashmap entry value initializers have 
+
+    //KNOWN_ROUTES needs to execute its initializer after its prospective hashmap entry value initializers have
     //executed, or else all keys will map to null
-    
-    private final static HashMap<String, ArrayList<WaypointPosition>> KNOWN_ROUTES = 
+
+    private final static HashMap<String, ArrayList<WaypointPosition>> KNOWN_ROUTES =
     		new HashMap<String, ArrayList<WaypointPosition>>() {
-    	
+
     	private static final long serialVersionUID = -8393587070456328149L;
 
 		{
-    		put("Vancouver Tour", VANCOUVER_TOUR);
+//     		put("Vancouver Tour", VANCOUVER_TOUR);
+            put("Pune Tour", PUNE_TOUR);
     		put("Vancouver North Shore Demo", VANCOUVER_NORTH_SHORE_DEMO);
     		put("Vancouver Low Altitude Tour", VANCOUVER_LOW_ALT_TOUR);
     		put("Vancouver Short Tour", VANCOUVER_SHORT_TOUR);
@@ -256,22 +271,22 @@ public abstract class KnownRoutes {
     		put("PTC NA Office Tour", PTC_NA_OFFICE_TOUR);
     	}
     };
-    
+
     //////////////////////////
     //utility methods
-    
+
 	/**
-	 * Resolve a list of waypoints by name. Trims trailing/leading whitespace from query strings. Attempts direct 
+	 * Resolve a list of waypoints by name. Trims trailing/leading whitespace from query strings. Attempts direct
 	 * string match of query string. Failing that, compares waypoint data
-	 * 
+	 *
 	 * @param query		The route name to look up
-	 * 
+	 *
 	 * @return	The resolved collection of waypoints, or null if no resolution could be made.
 	 */
 	public static ArrayList<WaypointPosition> lookupKnownRoute(String query) {
-		
+
 		query = query.trim();
-		
+
 		ArrayList<WaypointPosition> retval = null;
 
 		//direct lookup
@@ -279,70 +294,70 @@ public abstract class KnownRoutes {
 			LOGGER.info("Direct route lookup match for query '{}'", query);
 			retval = new ArrayList<WaypointPosition>();
 			retval.addAll( KNOWN_ROUTES.get(query) );
-		} else {			
+		} else {
 			//indirect lookup
 			//loose check of known routes ignoring whitespace and case
 			for( Entry<String, ArrayList<WaypointPosition>> entry : KNOWN_ROUTES.entrySet()) {
-				if(entry.getKey().equalsIgnoreCase(query) || 
+				if(entry.getKey().equalsIgnoreCase(query) ||
 					entry.getKey().replaceAll("\\s", "").equalsIgnoreCase(query.replaceAll("\\s", ""))
 				) {
-					
+
 					LOGGER.info("Indirect route lookup match for query '{}'", query);
-					
+
 					retval = entry.getValue();
-					
+
 					break;
 				} else {
 					LOGGER.debug("{} vs {}", entry, query );
 				}
 			}
 		}
-		
+
 		if(retval == null) {
 			LOGGER.warn("Route lookup failed for '{}'", query);
 		}
 
 		return retval;
 	}
-	
+
 	/**
 	 * Compare two routes by their waypoints and ordering
-	 * 
-	 * @param route1	
+	 *
+	 * @param route1
 	 * @param route2
-	 * 
+	 *
 	 * @return	True if both routes contain the same waypoint data, false otherwise
 	 */
 	public static boolean isEqual( ArrayList<WaypointPosition> route1, ArrayList<WaypointPosition> route2) {
-		
+
 		boolean retval = true;
 		if(route1 == null || route2 == null) {
 			retval = false;
 		} else if(route1.size() != route2.size()) {
 			retval = false;
 		} else {
-			
+
 			//compare contents. order matters
 			for(int i = 0; i< route1.size(); i++) {
-							
+
 				LOGGER.debug("Comparing waypoint {}\n{}\nvs\n{}", i, route1.get(i), route2.get(i));
-				
+
 				if( !route1.get(i).equals(route2.get(i)) ) {
 					retval = false;
 					break;
 				}
 			}
 		}
-		
+
 		return retval;
 	}
-    
-    public final static ArrayList<WaypointPosition> DEFAULT_ROUTE = 
+
+    public final static ArrayList<WaypointPosition> DEFAULT_ROUTE =
     		new ArrayList<WaypointPosition>() {
     	private static final long serialVersionUID = -8393587070456328149L;
 
 		{
-    		addAll(VANCOUVER_TOUR);
+    		addAll(PUNE_TOUR);
     	}
     };
 }

--- a/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
+++ b/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
@@ -20,7 +20,7 @@ public abstract class KnownRoutes {
     private final static Logger LOGGER = LoggerFactory.getLogger(KnownRoutes.class);
 
     public final static ArrayList<WaypointPosition> PUNE_TOUR = new ArrayList<WaypointPosition>() {
-
+             // Starting position for the route - Nagpur -> Amravati -> Bhusaval -> Ahmednagar -> Daund -> Pune Airport with starting position of Nagpur location (latitude, longitude) - 18.96902, 72.81795
             private static final long serialVersionUID = 3487720676170767955L;
 
             {
@@ -33,7 +33,7 @@ public abstract class KnownRoutes {
         };
 
     public final static ArrayList<WaypointPosition> DELHI_TOUR = new ArrayList<WaypointPosition>() {
-
+            // Starting position for the route - Mumbai Airport -> Surat -> Vadodara -> Ratlam -> Kota -> Delhi with starting position of Mumbai Airport location (latitude, longitude) - 21.09016, 79.05223
             private static final long serialVersionUID = 3487720676170767955L;
 
             {

--- a/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
+++ b/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
@@ -19,8 +19,9 @@ public abstract class KnownRoutes {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(KnownRoutes.class);
 
+    // initial heading yvr to Amravati City: 261
     public final static ArrayList<WaypointPosition> PUNE_TOUR = new ArrayList<WaypointPosition>() {
-             // Starting position for the route - Nagpur -> Amravati -> Bhusaval -> Ahmednagar -> Daund -> Pune Airport with starting position of Nagpur location (latitude, longitude) - 18.96902, 72.81795
+             // Starting position for the route - Nagpur -> Amravati -> Bhusaval -> Ahmednagar -> Daund -> Pune Airport with starting position of Nagpur location (latitude, longitude) - 21.09016, 79.05223
             private static final long serialVersionUID = 3487720676170767955L;
 
             {
@@ -32,8 +33,9 @@ public abstract class KnownRoutes {
             }
         };
 
+    // initial heading yvr to Surat City: 358
     public final static ArrayList<WaypointPosition> DELHI_TOUR = new ArrayList<WaypointPosition>() {
-            // Starting position for the route - Mumbai Airport -> Surat -> Vadodara -> Ratlam -> Kota -> Delhi with starting position of Mumbai Airport location (latitude, longitude) - 21.09016, 79.05223
+            // Starting position for the route - Mumbai Airport -> Surat -> Vadodara -> Ratlam -> Kota -> Delhi with starting position of Mumbai Airport location (latitude, longitude) - 18.96902, 72.81795
             private static final long serialVersionUID = 3487720676170767955L;
 
             {

--- a/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
+++ b/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
@@ -33,26 +33,40 @@ public abstract class KnownRoutes {
             }
         };
 
-//     public final static ArrayList<WaypointPosition> VANCOUVER_TOUR = new ArrayList<WaypointPosition>() {
-//
-//         private static final long serialVersionUID = 3487720676170767955L;
-//
-//         {
-//             add( KnownPositions.UBC );
-//             add( KnownPositions.STANLEY_PARK );
-//             add( KnownPositions.LONSDALE_QUAY );
-//             add( KnownPositions.MT_SEYMOUR );
-//             add( KnownPositions.GROUSE_MOUNTAIN );
-//             add( KnownPositions.WEST_LION );
-//             add( KnownPositions.LANGDALE );
-//             add( KnownPositions.BOWEN_BAY );
-//             add( KnownPositions.HORSESHOE_BAY );
-//             add( KnownPositions.MARPOLE_CC );
-//             add( KnownPositions.BURNABY_8RINKS );
-//             add( KnownPositions.PLANET_ICE_DELTA );
-//             add( KnownPositions.VAN_INTER_AIRPORT_YVR );
-//         }
-//     };
+    public final static ArrayList<WaypointPosition> DELHI_TOUR = new ArrayList<WaypointPosition>() {
+
+            private static final long serialVersionUID = 3487720676170767955L;
+
+            {
+               //add(KnownPositions.NAGPUR_AIRPORT)
+               add(KnownPositions.SURAT_CITY);
+               add(KnownPositions.VADODARA_CITY);
+               add(KnownPositions.RATLAM_CITY);
+               add(KnownPositions.KOTA_CITY);
+               add(KnownPositions.DELHI_CITY);
+            }
+        };
+
+    public final static ArrayList<WaypointPosition> VANCOUVER_TOUR = new ArrayList<WaypointPosition>() {
+
+        private static final long serialVersionUID = 3487720676170767955L;
+
+        {
+            add( KnownPositions.UBC );
+            add( KnownPositions.STANLEY_PARK );
+            add( KnownPositions.LONSDALE_QUAY );
+            add( KnownPositions.MT_SEYMOUR );
+            add( KnownPositions.GROUSE_MOUNTAIN );
+            add( KnownPositions.WEST_LION );
+            add( KnownPositions.LANGDALE );
+            add( KnownPositions.BOWEN_BAY );
+            add( KnownPositions.HORSESHOE_BAY );
+            add( KnownPositions.MARPOLE_CC );
+            add( KnownPositions.BURNABY_8RINKS );
+            add( KnownPositions.PLANET_ICE_DELTA );
+            add( KnownPositions.VAN_INTER_AIRPORT_YVR );
+        }
+    };
 
     //flight plan with minimal course corrections starting from hs bay
     public final static ArrayList<WaypointPosition> VANCOUVER_NORTH_SHORE_DEMO = new ArrayList<WaypointPosition>() {
@@ -256,7 +270,8 @@ public abstract class KnownRoutes {
     	private static final long serialVersionUID = -8393587070456328149L;
 
 		{
-//     		put("Vancouver Tour", VANCOUVER_TOUR);
+    		put("Vancouver Tour", VANCOUVER_TOUR);
+    		put("Delhi Tour", DELHI_TOUR);
             put("Pune Tour", PUNE_TOUR);
     		put("Vancouver North Shore Demo", VANCOUVER_NORTH_SHORE_DEMO);
     		put("Vancouver Low Altitude Tour", VANCOUVER_LOW_ALT_TOUR);

--- a/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
+++ b/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
@@ -19,7 +19,7 @@ public abstract class KnownRoutes {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(KnownRoutes.class);
 
-    // initial heading yvr to Amravati City: 261
+    // initial heading Nagpur to Amravati City: 261
     public final static ArrayList<WaypointPosition> PUNE_TOUR = new ArrayList<WaypointPosition>() {
              // Starting position for the route - Nagpur -> Amravati -> Bhusaval -> Ahmednagar -> Daund -> Pune Airport with starting position of Nagpur location (latitude, longitude) - 21.09016, 79.05223
             private static final long serialVersionUID = 3487720676170767955L;
@@ -33,7 +33,7 @@ public abstract class KnownRoutes {
             }
         };
 
-    // initial heading yvr to Surat City: 358
+    // initial heading Mumbai Airport to Surat City: 358
     public final static ArrayList<WaypointPosition> DELHI_TOUR = new ArrayList<WaypointPosition>() {
             // Starting position for the route - Mumbai Airport -> Surat -> Vadodara -> Ratlam -> Kota -> Delhi with starting position of Mumbai Airport location (latitude, longitude) - 18.96902, 72.81795
             private static final long serialVersionUID = 3487720676170767955L;

--- a/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
+++ b/src/main/java/org/jason/fgcontrol/flight/position/KnownRoutes.java
@@ -25,11 +25,11 @@ public abstract class KnownRoutes {
 
             {
                //add(KnownPositions.NAGPUR_AIRPORT)
-               add(KnownPositions.AMRAVATI_CITY)
-               add(KnownPositions.BHUSAVAL_CITY)
-               add(KnownPositions.AHMEDNAGAR_CITY)
-               add(KnownPositions.DAUND_CITY)
-               add(KnownPositions.PUNE_AIRPORT)
+               add(KnownPositions.AMRAVATI_CITY);
+               add(KnownPositions.BHUSAVAL_CITY);
+               add(KnownPositions.AHMEDNAGAR_CITY);
+               add(KnownPositions.DAUND_CITY);
+               add(KnownPositions.PUNE_AIRPORT);
             }
         };
 

--- a/src/main/test/org/jason/fgcontrol/test/KnownRoutesTest.java
+++ b/src/main/test/org/jason/fgcontrol/test/KnownRoutesTest.java
@@ -22,7 +22,7 @@ public class KnownRoutesTest {
 		
 		Assert.assertFalse(KnownRoutes.isEqual( new ArrayList<WaypointPosition>(), new ArrayList<WaypointPosition>(), KnownRoutes.VANCOUVER_TOUR ) );
 		
-		Assert.assertFalse(KnownRoutes.isEqual( KnownRoutes.PUNE_TOUR, new ArrayList<WaypointPosition>() ) );
+		Assert.assertFalse(KnownRoutes.isEqual( KnownRoutes.VANCOUVER_TOUR, new ArrayList<WaypointPosition>() ) );
 	}
 	
     @Test

--- a/src/main/test/org/jason/fgcontrol/test/KnownRoutesTest.java
+++ b/src/main/test/org/jason/fgcontrol/test/KnownRoutesTest.java
@@ -13,14 +13,14 @@ public class KnownRoutesTest {
 	
 	@Test
 	public void testIsEqual() {
-		Assert.assertTrue( KnownRoutes.isEqual( KnownRoutes.PUNE_TOUR, KnownRoutes.PUNE_TOUR) );
-		Assert.assertFalse( KnownRoutes.isEqual( KnownRoutes.PUNE_TOUR, KnownRoutes.BC_SOUTH_DEMO) );
+		Assert.assertTrue( KnownRoutes.isEqual( KnownRoutes.VANCOUVER_TOUR, KnownRoutes.VANCOUVER_TOUR) );
+		Assert.assertFalse( KnownRoutes.isEqual( KnownRoutes.VANCOUVER_TOUR, KnownRoutes.BC_SOUTH_DEMO) );
 
 		Assert.assertFalse(KnownRoutes.isEqual( null, null) );
 		
 		Assert.assertTrue(KnownRoutes.isEqual( new ArrayList<WaypointPosition>(), new ArrayList<WaypointPosition>()) );
 		
-		Assert.assertFalse(KnownRoutes.isEqual( new ArrayList<WaypointPosition>(), KnownRoutes.PUNE_TOUR ) );
+		Assert.assertFalse(KnownRoutes.isEqual( new ArrayList<WaypointPosition>(), new ArrayList<WaypointPosition>(), KnownRoutes.VANCOUVER_TOUR ) );
 		
 		Assert.assertFalse(KnownRoutes.isEqual( KnownRoutes.PUNE_TOUR, new ArrayList<WaypointPosition>() ) );
 	}
@@ -30,8 +30,8 @@ public class KnownRoutesTest {
         
     	Assert.assertTrue( 
     		KnownRoutes.isEqual(
-    			KnownRoutes.PUNE_TOUR,
-    			KnownRoutes.lookupKnownRoute("Pune Tour")
+    			KnownRoutes.VANCOUVER_TOUR,
+    			KnownRoutes.lookupKnownRoute("Vancouver Tour")
     		)
     	);
     }
@@ -41,8 +41,8 @@ public class KnownRoutesTest {
     	//Happy case indirect 
     	Assert.assertTrue( 
     		KnownRoutes.isEqual(
-    			KnownRoutes.PUNE_TOUR,
-    			KnownRoutes.lookupKnownRoute("pune tour")
+    			KnownRoutes.VANCOUVER_TOUR,
+    			KnownRoutes.lookupKnownRoute("vancouver tour")
     		)
     	);
     }
@@ -51,50 +51,50 @@ public class KnownRoutesTest {
     public void testDirectLookupWhitespace() {
     	Assert.assertTrue( 
     		KnownRoutes.isEqual(
-    			KnownRoutes.PUNE_TOUR,
-    			KnownRoutes.lookupKnownRoute("pune tour        ")
+    			KnownRoutes.VANCOUVER_TOUR,
+    			KnownRoutes.lookupKnownRoute("vancouver tour        ")
     		)
     	);
     	
     	Assert.assertTrue( 
         	KnownRoutes.isEqual(
-        		KnownRoutes.PUNE_TOUR,
-        		KnownRoutes.lookupKnownRoute("        pune tour       ")
+        		KnownRoutes.VANCOUVER_TOUR,
+        		KnownRoutes.lookupKnownRoute("        vancouver tour       ")
         	)
         );
     	
     	Assert.assertTrue( 
         	KnownRoutes.isEqual(
-        		KnownRoutes.PUNE_TOUR,
-        		KnownRoutes.lookupKnownRoute("pune tour\n")
+        		KnownRoutes.VANCOUVER_TOUR,
+        		KnownRoutes.lookupKnownRoute("vancouver tour\n")
         	)
         );
     	
     	Assert.assertTrue( 
            	KnownRoutes.isEqual(
-           		KnownRoutes.PUNE_TOUR,
-           		KnownRoutes.lookupKnownRoute("\tpune tour")
+           		KnownRoutes.VANCOUVER_TOUR,
+           		KnownRoutes.lookupKnownRoute("\tvancouver tour")
            	)
         );
     	
     	Assert.assertTrue( 
            	KnownRoutes.isEqual(
-           		KnownRoutes.PUNE_TOUR,
-           		KnownRoutes.lookupKnownRoute("pune tour\n\n\n\n")
+           		KnownRoutes.VANCOUVER_TOUR,
+           		KnownRoutes.lookupKnownRoute("vancouver tour\n\n\n\n")
            	)
         );
     	
     	Assert.assertTrue( 
     		KnownRoutes.isEqual(
-            	KnownRoutes.PUNE_TOUR,
-            	KnownRoutes.lookupKnownRoute("    pune tour\n\n\n\n")
+            	KnownRoutes.VANCOUVER_TOUR,
+            	KnownRoutes.lookupKnownRoute("    vancouver tour\n\n\n\n")
             )
         );
     	
     	Assert.assertTrue( 
            	KnownRoutes.isEqual(
-           		KnownRoutes.PUNE_TOUR,
-           		KnownRoutes.lookupKnownRoute("\n\n          \n\n\npune tour\n\n\n\n")
+           		KnownRoutes.VANCOUVER_TOUR,
+           		KnownRoutes.lookupKnownRoute("\n\n          \n\n\nvancouver tour\n\n\n\n")
            	)
         );
     }

--- a/src/main/test/org/jason/fgcontrol/test/KnownRoutesTest.java
+++ b/src/main/test/org/jason/fgcontrol/test/KnownRoutesTest.java
@@ -20,7 +20,7 @@ public class KnownRoutesTest {
 		
 		Assert.assertTrue(KnownRoutes.isEqual( new ArrayList<WaypointPosition>(), new ArrayList<WaypointPosition>()) );
 		
-		Assert.assertFalse(KnownRoutes.isEqual( new ArrayList<WaypointPosition>(), new ArrayList<WaypointPosition>(), KnownRoutes.VANCOUVER_TOUR ) );
+		Assert.assertFalse(KnownRoutes.isEqual( new ArrayList<WaypointPosition>(), KnownRoutes.VANCOUVER_TOUR ) );
 		
 		Assert.assertFalse(KnownRoutes.isEqual( KnownRoutes.VANCOUVER_TOUR, new ArrayList<WaypointPosition>() ) );
 	}

--- a/src/main/test/org/jason/fgcontrol/test/KnownRoutesTest.java
+++ b/src/main/test/org/jason/fgcontrol/test/KnownRoutesTest.java
@@ -13,16 +13,16 @@ public class KnownRoutesTest {
 	
 	@Test
 	public void testIsEqual() {
-		Assert.assertTrue( KnownRoutes.isEqual( KnownRoutes.VANCOUVER_TOUR, KnownRoutes.VANCOUVER_TOUR) );
-		Assert.assertFalse( KnownRoutes.isEqual( KnownRoutes.VANCOUVER_TOUR, KnownRoutes.BC_SOUTH_DEMO) );
-		
+		Assert.assertTrue( KnownRoutes.isEqual( KnownRoutes.PUNE_TOUR, KnownRoutes.PUNE_TOUR) );
+		Assert.assertFalse( KnownRoutes.isEqual( KnownRoutes.PUNE_TOUR, KnownRoutes.BC_SOUTH_DEMO) );
+
 		Assert.assertFalse(KnownRoutes.isEqual( null, null) );
 		
 		Assert.assertTrue(KnownRoutes.isEqual( new ArrayList<WaypointPosition>(), new ArrayList<WaypointPosition>()) );
 		
-		Assert.assertFalse(KnownRoutes.isEqual( new ArrayList<WaypointPosition>(), KnownRoutes.VANCOUVER_TOUR ) );
+		Assert.assertFalse(KnownRoutes.isEqual( new ArrayList<WaypointPosition>(), KnownRoutes.PUNE_TOUR ) );
 		
-		Assert.assertFalse(KnownRoutes.isEqual( KnownRoutes.VANCOUVER_TOUR, new ArrayList<WaypointPosition>() ) );
+		Assert.assertFalse(KnownRoutes.isEqual( KnownRoutes.PUNE_TOUR, new ArrayList<WaypointPosition>() ) );
 	}
 	
     @Test
@@ -30,8 +30,8 @@ public class KnownRoutesTest {
         
     	Assert.assertTrue( 
     		KnownRoutes.isEqual(
-    			KnownRoutes.VANCOUVER_TOUR, 
-    			KnownRoutes.lookupKnownRoute("Vancouver Tour")
+    			KnownRoutes.PUNE_TOUR,
+    			KnownRoutes.lookupKnownRoute("Pune Tour")
     		)
     	);
     }
@@ -41,8 +41,8 @@ public class KnownRoutesTest {
     	//Happy case indirect 
     	Assert.assertTrue( 
     		KnownRoutes.isEqual(
-    			KnownRoutes.VANCOUVER_TOUR, 
-    			KnownRoutes.lookupKnownRoute("vancouver tour")
+    			KnownRoutes.PUNE_TOUR,
+    			KnownRoutes.lookupKnownRoute("pune tour")
     		)
     	);
     }
@@ -51,50 +51,50 @@ public class KnownRoutesTest {
     public void testDirectLookupWhitespace() {
     	Assert.assertTrue( 
     		KnownRoutes.isEqual(
-    			KnownRoutes.VANCOUVER_TOUR, 
-    			KnownRoutes.lookupKnownRoute("vancouver tour        ")
+    			KnownRoutes.PUNE_TOUR,
+    			KnownRoutes.lookupKnownRoute("pune tour        ")
     		)
     	);
     	
     	Assert.assertTrue( 
         	KnownRoutes.isEqual(
-        		KnownRoutes.VANCOUVER_TOUR, 
-        		KnownRoutes.lookupKnownRoute("        vancouver tour       ")
+        		KnownRoutes.PUNE_TOUR,
+        		KnownRoutes.lookupKnownRoute("        pune tour       ")
         	)
         );
     	
     	Assert.assertTrue( 
         	KnownRoutes.isEqual(
-        		KnownRoutes.VANCOUVER_TOUR, 
-        		KnownRoutes.lookupKnownRoute("vancouver tour\n")
+        		KnownRoutes.PUNE_TOUR,
+        		KnownRoutes.lookupKnownRoute("pune tour\n")
         	)
         );
     	
     	Assert.assertTrue( 
            	KnownRoutes.isEqual(
-           		KnownRoutes.VANCOUVER_TOUR, 
-           		KnownRoutes.lookupKnownRoute("\tvancouver tour")
+           		KnownRoutes.PUNE_TOUR,
+           		KnownRoutes.lookupKnownRoute("\tpune tour")
            	)
         );
     	
     	Assert.assertTrue( 
            	KnownRoutes.isEqual(
-           		KnownRoutes.VANCOUVER_TOUR, 
-           		KnownRoutes.lookupKnownRoute("vancouver tour\n\n\n\n")
+           		KnownRoutes.PUNE_TOUR,
+           		KnownRoutes.lookupKnownRoute("pune tour\n\n\n\n")
            	)
         );
     	
     	Assert.assertTrue( 
     		KnownRoutes.isEqual(
-            	KnownRoutes.VANCOUVER_TOUR, 
-            	KnownRoutes.lookupKnownRoute("    vancouver tour\n\n\n\n")
+            	KnownRoutes.PUNE_TOUR,
+            	KnownRoutes.lookupKnownRoute("    pune tour\n\n\n\n")
             )
         );
     	
     	Assert.assertTrue( 
            	KnownRoutes.isEqual(
-           		KnownRoutes.VANCOUVER_TOUR, 
-           		KnownRoutes.lookupKnownRoute("\n\n          \n\n\nvancouver tour\n\n\n\n")
+           		KnownRoutes.PUNE_TOUR,
+           		KnownRoutes.lookupKnownRoute("\n\n          \n\n\npune tour\n\n\n\n")
            	)
         );
     }


### PR DESCRIPTION
For running the flight for Delhi Tour, this command needs to be executed in the scripts folder -./f15c_flight.sh 5220 103 21.09016 79.05223 f15c_beta
And this command needs to be executed at the root of flightgear-control - /usr/lib/jvm/java-8-openjdk-amd64/bin/java -cp build/libs/flightgear-control-0.4-app.jar org.jason.fgcontrol.aircraft.f15c.app.WaypointFlight scripts/conf/f15c/f15c_beta_flight_mumbai_to_delhi.properties

For running the flight for Pune Tour, this command needs to be executed in the scripts folder - ./f15c_flight.sh 5220 103 18.96902 72.81795 f15c_beta
And this command needs to be executed at the root of flightgear-control - /usr/lib/jvm/java-8-openjdk-amd64/bin/java -cp build/libs/flightgear-control-0.4-app.jar org.jason.fgcontrol.aircraft.f15c.app.WaypointFlight scripts/conf/f15c/f15c_beta_flight_ngp_to_pune.properties
