### PR TITLE
Add engine carburetor ice amount to c172p state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ scripts/updateProtocolFiles.sh
 /*.gpx
 
 # common test output file
-output
+/output
 
 #ignore for Project
 .DS_Store

--- a/protocol/input/c172p/c172p_input_engines.xml
+++ b/protocol/input/c172p/c172p_input_engines.xml
@@ -7,6 +7,11 @@
  
          <!-- engines -->
          <chunk>
+            <node>/engines/active-engine/carb_ice</node>
+            <name>carb_ice</name>
+            <type>float</type>
+         </chunk>
+         <chunk>
             <node>/engines/active-engine/complex-engine-procedures</node>
             <name>complex-engine-procedures</name>
             <type>bool</type>

--- a/protocol/output/c172p/c172p_output.xml
+++ b/protocol/output/c172p/c172p_output.xml
@@ -158,6 +158,12 @@
          </chunk>
          <!-- engines - only one engine on the c172p -->
          <chunk>
+            <node>/engines/active-engine/carb_ice</node>
+            <name>carb_ice</name>
+            <type>float</type>
+            <format>"/engines/active-engine/carb_ice": %f,</format>
+         </chunk>
+         <chunk>
             <node>/engines/active-engine/complex-engine-procedures</node>
             <name>complex-engine-procedures</name>
             <type>bool</type>

--- a/src/main/java/org/jason/fgcontrol/aircraft/c172p/C172P.java
+++ b/src/main/java/org/jason/fgcontrol/aircraft/c172p/C172P.java
@@ -343,6 +343,18 @@ public class C172P extends FlightGearAircraft {
     ///////////////////
     //engine
     
+	public Double getCarbIce() {
+		return Double.parseDouble(getTelemetryField(C172PFields.ENGINES_CARB_ICE));
+	}
+
+	public int getComplexEngineProcedures() {
+		return Character.getNumericValue(getTelemetryField(C172PFields.ENGINES_COMPLEX_ENGINE_PROCEDURES).charAt(0));
+	}
+
+	public boolean isComplexEngineProceduresEnabled() {
+		return getComplexEngineProcedures() == C172PFields.ENGINES_COMPLEX_ENGINE_PROCEDURES_INT_TRUE;
+	}
+
     public double getCowlingAirTemperature() {
         return Double.parseDouble(getTelemetryField(C172PFields.ENGINES_COWLING_AIR_TEMPERATURE_FIELD));
     }

--- a/src/main/java/org/jason/fgcontrol/aircraft/c172p/C172P.java
+++ b/src/main/java/org/jason/fgcontrol/aircraft/c172p/C172P.java
@@ -601,7 +601,16 @@ public class C172P extends FlightGearAircraft {
         LOGGER.info("Toggling anti-ice heaters: {}", enabled);
         
         writeControlInput(inputHash, this.controlInputConnection);
+    }
 
+    public synchronized void setCarbIce(double iceAmount) throws IOException {
+        LinkedHashMap<String, String> inputHash = copyStateFields(C172PFields.ENGINES_INPUT_FIELDS);
+
+        inputHash.put(C172PFields.ENGINES_CARB_ICE, String.valueOf(iceAmount));
+
+        LOGGER.info("Setting carburetor ice amount: {}", iceAmount);
+
+        writeControlInput(inputHash, this.enginesInputConnection);
     }
     
     public synchronized void setComplexEngineProcedures(boolean enabled) throws IOException {

--- a/src/main/java/org/jason/fgcontrol/aircraft/c172p/C172PFields.java
+++ b/src/main/java/org/jason/fgcontrol/aircraft/c172p/C172PFields.java
@@ -181,6 +181,9 @@ public abstract class C172PFields {
     /////////////
     // engines
     
+    public final static String ENGINES_CARB_ICE = "/engines/active-engine/carb_ice";
+    public final static String ENGINES_CARB_ICE_DESC = "Amount of ice accumulated in the engine carburetor";
+
     public final static String ENGINES_COMPLEX_ENGINE_PROCEDURES = "/engines/active-engine/complex-engine-procedures";
     public final static String ENGINES_COMPLEX_ENGINE_PROCEDURES_DESC = "Toggle complex engine procedures and failures for the C172P. Disable for easier flight management";
     
@@ -247,6 +250,7 @@ public abstract class C172PFields {
     };
     
     public final static String[] ENGINES_INPUT_FIELDS = {
+    	ENGINES_CARB_ICE,
         ENGINES_COMPLEX_ENGINE_PROCEDURES,
         ENGINES_WINTER_KIT_INSTALLED
     };


### PR DESCRIPTION
Add the `carb_ice` field for the active engine, and getter/setter methods around it.

Increasing this value will make the engine operate less efficiently, and a drop in engine rpms will be observed- useful for introducing and resolving a mechanical problem.

Setting this value requires `/engines/active-engine/complex-engine-procedures` to be enabled.